### PR TITLE
Add a header in `signal.c`

### DIFF
--- a/tools/service-launcher/signals.c
+++ b/tools/service-launcher/signals.c
@@ -35,7 +35,7 @@
 #include <sys/user.h>
 #include <sys/types.h>
 #include <sys/ptrace.h>
-
+#include <stdlib.h>
 #include "utils.h"
 #include "signals.h"
 


### PR DESCRIPTION
Or it will throw the error:

```
signals.c:335:28: error: implicit declaration of function ‘calloc’ [-Werror=implicit-function-declaration]
  335 |     cntrs = (struct cntr *)calloc(ncntrs, sizeof(*cntrs));
```

during `make`